### PR TITLE
Add `'use strict';` to the top of all source files

### DIFF
--- a/lib/closest.js
+++ b/lib/closest.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const matches = require('./matches')
 
 module.exports = function closest(node, selector) {

--- a/lib/create.js
+++ b/lib/create.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function create(str) {
   const div = document.createElement('div')
   div.innerHTML = str && str.trim()

--- a/lib/hide.js
+++ b/lib/hide.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function hide(el) {
   el.style.display = 'none'
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const create = require('./create')
 const hide = require('./hide')
 const offset = require('./offset')

--- a/lib/matches.js
+++ b/lib/matches.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = (node, selector) => {
   const matchesMethod =
     Element.prototype.matches ||

--- a/lib/offset.js
+++ b/lib/offset.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function offset(el) {
   const rect = el.getBoundingClientRect()
   return {

--- a/lib/query-all.js
+++ b/lib/query-all.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function queryAll(query, el = document) {
   return el.querySelectorAll(query)
 }

--- a/lib/query.js
+++ b/lib/query.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function query(queryStr, el = document) {
   return el.querySelector(queryStr)
 }

--- a/lib/remove.js
+++ b/lib/remove.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function (el) {
   if (el && el.parentNode) {
     el.parentNode.removeChild(el);

--- a/lib/show.js
+++ b/lib/show.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const memoize = require('fast-memoize')
 
 const getDefaultDisplay = memoize(nodeName => {


### PR DESCRIPTION
This resolves a SyntaxError issue seen in Safari 13.1 when bundling corleone.js with webpack 4.43.0, babel-loader 8.1.0, and Babel 7.9.x:

<img width="994" alt="Screen Shot 2020-04-27 at 10 28 23 AM" src="https://user-images.githubusercontent.com/191304/80383880-2c5a8300-8872-11ea-8b0c-58837cd3618d.png">

<img width="530" alt="Screen Shot 2020-04-27 at 10 28 11 AM" src="https://user-images.githubusercontent.com/191304/80383893-311f3700-8872-11ea-8399-dc72e9621eb4.png">
